### PR TITLE
Fix ADD_COMMENTS_AS_SUBNET_NAME setting and add VLAN_DESC_AS_SUBNET_NAME setting

### DIFF
--- a/infoblox2device42.cfg.sample
+++ b/infoblox2device42.cfg.sample
@@ -30,3 +30,5 @@ MAX_THREADS                 = 20
 DRY_RUN                     = False
 #If you want to strip the domain name part from the hostname:
 IGNORE_DOMAIN               = False  
+#Use VLAN Description as Device42 Subnet Name (Requires API 2.0 or newer)
+VLAN_DESC_AS_SUBNET_NAME    = False

--- a/infoblox2device42.cfg.sample
+++ b/infoblox2device42.cfg.sample
@@ -3,7 +3,8 @@
 BLOX_HOST   = Blox_Host_IP
 BLOX_USER   = Blox_user
 BLOX_PASS   = Blox_password
-BLOX_URL    = https://BLOX_HOST/wapi/v1.2/
+BLOX_API    = v1.2
+BLOX_URL    = https://BLOX_HOST/wapi/BLOX_API/
 
 [d42]
 # Device42 upload settings  #

--- a/infoblox2device42.py
+++ b/infoblox2device42.py
@@ -104,7 +104,10 @@ class InfobloxNetworks():
         
         if not self.session:
             self.connect()
-        r = self.session.get(BLOX_URL + 'network')
+        if VLAN_DESC_AS_SUBNET_NAME:
+            r = self.session.get(BLOX_URL + 'network?_return_fields=network,extattrs')
+        else:
+            r = self.session.get(BLOX_URL + 'network')
         data = json.loads(r.text)
         if DEBUG:
             lock.acquire()
@@ -129,6 +132,14 @@ class InfobloxNetworks():
                     subnet.update({'name':comment})
                 except:
                     pass
+
+            if VLAN_DESC_AS_SUBNET_NAME:
+                try:
+                    comment = netinfo['extattrs']['VLAN Description']['value']
+                    subnet.update({'name':comment})
+                except:
+                    pass
+
             if subnet:
                 print '[+] Subnet: %s' % network
                 self.rest.post_subnet(subnet)
@@ -148,6 +159,17 @@ class InfobloxNetworks():
             netinfo = json.loads(r.text)
             try:
                 comment = netinfo[0]['comment']
+                subnet.update({'name':comment})
+            except:
+                pass
+
+        if VLAN_DESC_AS_SUBNET_NAME:
+            if not self.session:
+                self.connect()
+            r = self.session.get(BLOX_URL + 'network?_return_fields=network,extattrs&network='+NET)
+            netinfo = json.loads(r.text)
+            try:
+                comment = netinfo[0]['extattrs']['VLAN Description']['value']
                 subnet.update({'name':comment})
             except:
                 pass
@@ -391,12 +413,14 @@ def read_settings():
         MAX_THREADS                 = cc.get('other', 'MAX_THREADS')
         IGNORE_DOMAIN               = cc.getboolean('other', 'IGNORE_DOMAIN')
         DRY_RUN                     = cc.getboolean('other', 'DRY_RUN')
+        VLAN_DESC_AS_SUBNET_NAME    = cc.getboolean('other', 'VLAN_DESC_AS_SUBNET_NAME')
         # --------------------------------------------------------------------------------------------------------------------------
 
         return   BLOX_HOST, BLOX_USER, BLOX_PASS, BLOX_API, BLOX_URL, \
                     D42_USER, D42_PWD, D42_URL, DRY_RUN, \
                     TARGET_NETWORKS , ADD_COMMENTS_AS_SUBNET_NAME, \
-                    GET_ASSOCIATED_DEVICE,  DEBUG, MAX_THREADS, IGNORE_DOMAIN
+                    GET_ASSOCIATED_DEVICE,  DEBUG, MAX_THREADS, IGNORE_DOMAIN, \
+                    VLAN_DESC_AS_SUBNET_NAME
 
 def main():
     if TARGET_NETWORKS in ('', ' ', '\n', 'None'):
@@ -446,7 +470,9 @@ if __name__ == '__main__':
     BLOX_HOST, BLOX_USER, BLOX_PASS, BLOX_API, BLOX_URL, \
     D42_USER, D42_PWD, D42_URL, DRY_RUN, \
     TARGET_NETWORKS , ADD_COMMENTS_AS_SUBNET_NAME, \
-    GET_ASSOCIATED_DEVICE,  DEBUG, MAX_THREADS, IGNORE_DOMAIN = read_settings()
+    GET_ASSOCIATED_DEVICE,  DEBUG, MAX_THREADS, IGNORE_DOMAIN, \
+    VLAN_DESC_AS_SUBNET_NAME = read_settings()
+    
     BLOX_URL = BLOX_URL.replace('BLOX_HOST', BLOX_HOST)
     BLOX_URL = BLOX_URL.replace('BLOX_API', BLOX_API)
     

--- a/infoblox2device42.py
+++ b/infoblox2device42.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import os
 import json
@@ -362,6 +364,7 @@ def read_settings():
         BLOX_HOST = cc.get('blox', 'BLOX_HOST')
         BLOX_USER = cc.get('blox', 'BLOX_USER')
         BLOX_PASS = cc.get('blox', 'BLOX_PASS')
+        BLOX_API  = cc.get('blox', 'BLOX_API')
         BLOX_URL   = cc.get('blox', 'BLOX_URL')
         # D42
         D42_USER   = cc.get('d42', 'D42_USER')
@@ -378,7 +381,7 @@ def read_settings():
         DRY_RUN                     = cc.getboolean('other', 'DRY_RUN')
         # --------------------------------------------------------------------------------------------------------------------------
 
-        return   BLOX_HOST, BLOX_USER, BLOX_PASS, BLOX_URL, \
+        return   BLOX_HOST, BLOX_USER, BLOX_PASS, BLOX_API, BLOX_URL, \
                     D42_USER, D42_PWD, D42_URL, DRY_RUN, \
                     TARGET_NETWORKS , ADD_COMMENTS_AS_SUBNET_NAME, \
                     GET_ASSOCIATED_DEVICE,  DEBUG, MAX_THREADS, IGNORE_DOMAIN
@@ -428,11 +431,12 @@ def main():
 
 if __name__ == '__main__':
     
-    BLOX_HOST, BLOX_USER, BLOX_PASS, BLOX_URL, \
+    BLOX_HOST, BLOX_USER, BLOX_PASS, BLOX_API, BLOX_URL, \
     D42_USER, D42_PWD, D42_URL, DRY_RUN, \
     TARGET_NETWORKS , ADD_COMMENTS_AS_SUBNET_NAME, \
     GET_ASSOCIATED_DEVICE,  DEBUG, MAX_THREADS, IGNORE_DOMAIN = read_settings()
     BLOX_URL = BLOX_URL.replace('BLOX_HOST', BLOX_HOST)
+    BLOX_URL = BLOX_URL.replace('BLOX_API', BLOX_API)
     
     main()
     sys.exit()

--- a/infoblox2device42.py
+++ b/infoblox2device42.py
@@ -140,6 +140,18 @@ class InfobloxNetworks():
         net, mask = NET.split('/')
         subnet.update({'network':net})
         subnet.update({'mask_bits':mask})
+
+        if ADD_COMMENTS_AS_SUBNET_NAME:
+            if not self.session:
+                self.connect()
+            r = self.session.get(BLOX_URL + 'network?network='+NET)
+            netinfo = json.loads(r.text)
+            try:
+                comment = netinfo[0]['comment']
+                subnet.update({'name':comment})
+            except:
+                pass
+
         self.rest.post_subnet(subnet)
 
 


### PR DESCRIPTION
The first commit splits the Infoblox API out into a variable and adds a shebang to the top of the script.

The second commit makes the ADD_COMMENTS_AS_SUBNET_NAME setting work when TARGET_NETWORKS is set to something other than None.

The third commit adds a new setting VLAN_DESC_AS_SUBNET_NAME.  This uses the "VLAN Description" field for a network in Infoblox as the Subnet Name in Device42.  Our environment didn't have the comment field filled in for most of our networks, but it did have the VLAN Description.  It does require Infoblox API 2.0 or newer to work though.
